### PR TITLE
Use English translations for missing languages

### DIFF
--- a/addon/globalPlugins/ThunderbirdGlob.py
+++ b/addon/globalPlugins/ThunderbirdGlob.py
@@ -11,8 +11,9 @@ if not hasattr(controlTypes, "Role"):
 	[(x.split("STATE_")[1], getattr(controlTypes, x)) for x in dir(controlTypes) if x.startswith("STATE_")])))
 	setattr(controlTypes, "role", type("role", (), {"_roleLabels": controlTypes.roleLabels}))
 # End of compatibility fixes
-import globalPluginHandler, addonHandler
-addonHandler.initTranslation()
+import globalPluginHandler
+from .shared import translation
+translation.initTranslationWithEnglishFallback()
 import api
 import ui
 import speech

--- a/addon/globalPlugins/shared/translation.py
+++ b/addon/globalPlugins/shared/translation.py
@@ -1,0 +1,58 @@
+# -*- coding:utf-8 -*
+# translation.py
+# A part of Thunderbird+ 4.0  for Thunderbird 102
+# Copyright (C) 2023 Cyrille Bougot
+# This file is covered by the GNU General Public License version 2 or later.
+
+"""This module provides a tool for add-ons written in another language than English.
+
+If the translatable messages in your add-on are not in English (e.g. French), using
+`addonHandler.initTranslation` will cause gettext (`_`) to return French messages for languages with no translation.
+This module provides a function that allow gettext (`_`) to return English messages instead.
+
+To use it, on top of your modules, call `translations.initTranslationWithEnglishFallback()` instead
+of `addonHandler.initTranslation`.
+"""
+
+import os
+import inspect
+import gettext
+import addonHandler
+import languageHandler
+
+
+# Modified function based on initTranslation in addonHandler/__init__.py
+def initTranslationWithEnglishFallback():
+	addon = addonHandler.getCodeAddon(frameDist=2)
+	# Call our getTranslationsInstance instead of normal one.
+	translations = getTranslationsInstance(addon)
+	# Point _ to the translation object in the globals namespace of the caller frame
+	# FIXME: should we retrieve the caller module object explicitly?
+	try:
+		callerFrame = inspect.currentframe().f_back
+		callerFrame.f_globals['_'] = translations.gettext
+		# Install our pgettext function.
+		callerFrame.f_globals['pgettext'] = languageHandler.makePgettext(translations)
+	finally:
+		del callerFrame # Avoid reference problems with frames (per python docs)
+
+# Modified function based on Addon.getTranslationsInstance in addonHandler/__init__.py
+def getTranslationsInstance(addon, domain='nvda'):
+	""" Gets the gettext translation instance for this add-on.
+	<addon-path>\\locale will be used to find .mo files, if exists.
+	NVDA's language is used to search for translations; if no translation exists for this language, English is
+	used.
+	If no translation file is found the default fallback null translation is returned.
+	@param domain: the translation domain to retrieve. The 'nvda' default should be used in most cases.
+	@returns: the gettext translation class.
+	"""
+	localedir = os.path.join(addon.path, "locale")
+	return gettext.translation(
+		domain,
+		localedir=localedir,
+		# If language not available, use English as second try
+		languages=[languageHandler.getLanguage(), "en"],
+		fallback=True,
+	)
+
+

--- a/addon/globalPlugins/shared/updateLite.py
+++ b/addon/globalPlugins/shared/updateLite.py
@@ -10,8 +10,8 @@ import api, globalVars
 import os, wx
 import  gui
 from ui import  message, browseableMessage
-import addonHandler
-addonHandler.initTranslation()
+from . import translation
+translation.initTranslationWithEnglishFallback()
 import time, winUser
 import config
 from tones import beep


### PR DESCRIPTION
Hello Pierre-Louis

Here is a code to have the translatable messages translated to English instead of French when no translation exists for a specific language.

This code only applies to the globalPlugin part since I have not Thunderbird installed to test the AppModule part. So there is remaining work to adapt it to appModule code files. And also to import the file from both locations (or duplicate if not easy to import).

You can take this branch and continue the work in it and then merge it. Or merge it as is and add the remaining work later.

Feel free to ask for more help here, on the French mailing list or on my personal e-mail.

